### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: ["develop", "feature/**", "fix/**"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PolyTorus/polytorus/security/code-scanning/2](https://github.com/PolyTorus/polytorus/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out the repository and runs tests, it does not require write permissions. The minimal permissions required are `contents: read`. This block can be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
